### PR TITLE
create the new component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     decidim-reporting_proposals (0.1.0)
       decidim-core (>= 0.25.0, < 0.27)
+      decidim-proposals (>= 0.25.0, < 0.27)
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/concerns/decidim/reporting_proposals/admin/needs_header_snippets.rb
+++ b/app/controllers/concerns/decidim/reporting_proposals/admin/needs_header_snippets.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ReportingProposals
+    module Admin
+      # Exposes the proposal resource so users can view and create them.
+      module NeedsHeaderSnippets
+        extend ActiveSupport::Concern
+
+        included do
+          helper_method :snippets
+        end
+
+        def snippets
+          @snippets ||= Decidim::Snippets.new
+
+          unless @snippets.any?(:reporting_proposals_snippets) && reporting_proposals_component?
+            @snippets.add(:reporting_proposals_snippets, ActionController::Base.helpers.stylesheet_pack_tag("decidim_reporting_proposals_component_admin"))
+            @snippets.add(:head, @snippets.for(:reporting_proposals_snippets))
+          end
+
+          @snippets
+        end
+
+        def reporting_proposals_component?
+          current_component&.manifest_name == "reporting_proposals"
+        end
+
+        def current_component
+          return unless query_scope && query_scope.respond_to?(:find)
+
+          @current_component ||= query_scope.find(params[:id])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/decidim/reporting_proposals/proposals_controller_override.rb
+++ b/app/controllers/concerns/decidim/reporting_proposals/proposals_controller_override.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ReportingProposals
+    # Exposes the proposal resource so users can view and create them.
+    module ProposalsControllerOverride
+      extend ActiveSupport::Concern
+
+      included do
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/decidim/reporting_proposals/proposals_controller_override.rb
+++ b/app/controllers/concerns/decidim/reporting_proposals/proposals_controller_override.rb
@@ -7,6 +7,16 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
+        def complete
+          enforce_permission_to :edit, :proposal, proposal: @proposal
+          @step = :step_3
+
+          @form = form_proposal_model
+
+          @form.attachment = form_attachment_new
+
+          redirect_to "#{Decidim::ResourceLocatorPresenter.new(@proposal).path}/preview" if @form.component.manifest_name == "reporting_proposals"
+        end
       end
     end
   end

--- a/app/helpers/concerns/decidim/reporting_proposals/proposal_wizard_helper_override.rb
+++ b/app/helpers/concerns/decidim/reporting_proposals/proposal_wizard_helper_override.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ReportingProposals
+    # Exposes the proposal resource so users can view and create them.
+    module ProposalWizardHelperOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def proposal_wizard_stepper(current_step)
+          steps = %(
+            #{proposal_wizard_stepper_step(:step_1, current_step)}
+            #{proposal_wizard_stepper_step(:step_2, current_step)}
+          )
+          steps = %(#{steps} #{proposal_wizard_stepper_step(:step_3, current_step)}) unless reporting_proposals_component?
+          steps = %(#{steps} #{proposal_wizard_stepper_step(:step_4, current_step)})
+
+          content_tag :ol, class: "wizard__steps" do
+            steps.html_safe
+          end
+        end
+
+        private
+
+        def total_steps
+          reporting_proposals_component? ? 3 : 4
+        end
+
+        # rubocop:disable Rails/HelperInstanceVariable:
+        def reporting_proposals_component?
+          return unless @form&.component&.manifest_name
+
+          @form.component.manifest_name == "reporting_proposals"
+        end
+        # rubocop:enable Rails/HelperInstanceVariable:
+      end
+    end
+  end
+end

--- a/app/packs/entrypoints/decidim_reporting_proposals_component_admin.js
+++ b/app/packs/entrypoints/decidim_reporting_proposals_component_admin.js
@@ -1,0 +1,1 @@
+import "stylesheets/decidim/reporting_proposals/component_admin.scss";

--- a/app/packs/stylesheets/decidim/reporting_proposals/component_admin.scss
+++ b/app/packs/stylesheets/decidim/reporting_proposals/component_admin.scss
@@ -1,0 +1,5 @@
+.global-settings,.step-settings {
+	.readonly_container {
+		display: none;
+	}
+}

--- a/app/validators/concerns/decidim/reporting_proposals/component_validator_override.rb
+++ b/app/validators/concerns/decidim/reporting_proposals/component_validator_override.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ReportingProposals
+    # Exposes the proposal resource so users can view and create them.
+    module ComponentValidatorOverride
+      extend ActiveSupport::Concern
+
+      included do
+        # The actual validator method. It is called when ActiveRecord iterates
+        # over all the validators.
+        def validate_each(record, attribute, component)
+          unless component
+            record.errors[attribute] << :blank
+            return
+          end
+          manifests = [options[:manifest].to_s]
+          manifests << "reporting_proposals" if manifests.first == "proposals"
+
+          record.errors[attribute] << :invalid unless component.manifest_name.to_s.in?(manifests)
+        end
+      end
+    end
+  end
+end

--- a/config/assets.rb
+++ b/config/assets.rb
@@ -4,5 +4,6 @@ base_path = File.expand_path("..", __dir__)
 
 Decidim::Webpacker.register_path("#{base_path}/app/packs")
 Decidim::Webpacker.register_entrypoints(
-  decidim_reporting_proposals: "#{base_path}/app/packs/entrypoints/decidim_reporting_proposals.js"
+  decidim_reporting_proposals: "#{base_path}/app/packs/entrypoints/decidim_reporting_proposals.js",
+  decidim_reporting_proposals_component_admin: "#{base_path}/app/packs/entrypoints/decidim_reporting_proposals_component_admin.js"
 )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,2 +1,132 @@
 ---
 en:
+  decidim:
+    components:
+      reporting_proposals:
+        name: Reporting proposals
+        settings:
+          global:
+            amendments_enabled: Amendments enabled
+            amendments_enabled_help: If active, configure Amendment features for each
+              step.
+            amendments_wizard_help_text: Amendments Wizard help text
+            announcement: Announcement
+            attachments_allowed: Allow attachments
+            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond
+              threshold
+            collaborative_drafts_enabled: Collaborative drafts enabled
+            comments_enabled: Comments enabled
+            comments_max_length: Comments max length (Leave 0 for default value)
+            default_sort_order: Default proposal sorting
+            default_sort_order_help: Default means that if the supports are enabled,
+              the proposals will be shown sorted by random, and if the supports are
+              blocked, then they will be sorted by the most supported.
+            default_sort_order_options:
+              default: Default
+              most_commented: Most commented
+              most_endorsed: Most endorsed
+              most_followed: Most followed
+              most_voted: Most supported
+              random: Random
+              recent: Recent
+              with_more_authors: With more authors
+            geocoding_enabled: Geocoding enabled
+            minimum_votes_per_user: Minimum supports per user
+            new_proposal_body_template: New proposal body template
+            new_proposal_body_template_help: You can define prefilled text that the
+              new Proposals will have
+            new_proposal_help_text: New proposal help text
+            official_proposals_enabled: Official proposals enabled
+            participatory_texts_enabled: Participatory texts enabled
+            participatory_texts_enabled_readonly: Cannot interact with this setting
+              if there are existing proposals. Please, create a new `Proposals component`
+              if you want to enable this feature or discard all imported proposals
+              in the `Participatory Texts` menu if you want to disable it.
+            proposal_answering_enabled: Proposal answering enabled
+            proposal_edit_before_minutes: Proposals can be edited by authors before
+              this many minutes passes
+            proposal_edit_time: Proposal editing
+            proposal_edit_time_choices:
+              infinite: Allow editing proposals for an infinite amount of time
+              limited: Allow editing of proposals within a specific timeframe
+            proposal_length: Maximum proposal body length
+            proposal_limit: Proposal limit per participant
+            proposal_wizard_step_1_help_text: Proposal wizard "Create" step help text
+            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help
+              text
+            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help
+              text
+            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help
+              text
+            resources_permissions_enabled: Actions permissions can be set for each
+              proposal
+            scope_id: Scope
+            scopes_enabled: Scopes enabled
+            threshold_per_proposal: Threshold per proposal
+            vote_limit: Support limit per participant
+          step:
+            amendment_creation_enabled: Amendment creation enabled
+            amendment_creation_enabled_help: Participant can amend proposals.
+            amendment_promotion_enabled: Amendment promotion enabled
+            amendment_promotion_enabled_help: Emandation authors will be able to promote
+              to Proposal the rejected emendation.
+            amendment_reaction_enabled: Amendment reaction enabled
+            amendment_reaction_enabled_help: Proposal's authors will be able to accept
+              or reject Participant's emendations.
+            amendments_visibility: Amendments visibility
+            amendments_visibility_choices:
+              all: Amendments are visible to all
+              participants: Amendments are visible only to their authors
+            amendments_visibility_help: If the option "Amendments are visible only
+              to their authors" is selected, participant must be logged in to see
+              the amendments made.
+            announcement: Announcement
+            answers_with_costs: Enable costs on proposal answers
+            automatic_hashtags: Hashtags added to all proposals
+            comments_blocked: Comments blocked
+            creation_enabled: Participants can create proposals
+            creation_enabled_readonly: This setting is disabled when you activate
+              the Participatory Texts functionality. To upload proposals as participatory
+              text click on the Participatory Texts button and follow the instructions.
+            default_sort_order: Default proposal sorting
+            default_sort_order_help: Default it means that if the supports are enabled,
+              the proposals will be shown sorted by random, and if the supports are
+              blocked, then they will be sorted by the most supported.
+            default_sort_order_options:
+              default: Default
+              most_commented: Most commented
+              most_endorsed: Most endorsed
+              most_followed: Most followed
+              most_voted: Most supported
+              random: Random
+              recent: Recent
+              with_more_authors: With more authors
+            endorsements_blocked: Endorsements blocked
+            endorsements_enabled: Endorsements enabled
+            proposal_answering_enabled: Proposal answering enabled
+            publish_answers_immediately: Publish proposal answers immediately
+            publish_answers_immediately_help_html: Mind that if you answer any proposal
+              without this enabled, you'll need to publish them manually by selecting
+              them and using the action for publication. For more info on how this
+              works, see <a href="https://docs.decidim.org/en/admin/components/proposals/answers#_publication"
+              target="_blank">proposals' answers documentation page</a>.
+            suggested_hashtags: Hashtags suggested to participants for new proposals
+            votes_blocked: Supports blocked
+            votes_enabled: Supports enabled
+            votes_hidden: Supports hidden (if supports are enabled, checking this
+              will hide the number of supports)
+    reporting_proposals:
+      actions:
+        answer_proposal: Answer proposal
+        edit_proposal: Edit proposal
+        import: Import proposals from another component
+        new: New proposal
+        participatory_texts: Participatory texts
+        show: Show proposal
+        title: Actions
+      admin:
+        actions:
+          preview: Preview
+        exports:
+          proposal_comments: Comments
+          proposals: Reporting proposals

--- a/decidim-reporting_proposals.gemspec
+++ b/decidim-reporting_proposals.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "decidim-core", Decidim::ReportingProposals::COMPAT_DECIDIM_VERSION
+  spec.add_dependency "decidim-proposals", Decidim::ReportingProposals::COMPAT_DECIDIM_VERSION
 
   spec.add_development_dependency "decidim-dev", Decidim::ReportingProposals::COMPAT_DECIDIM_VERSION
 end

--- a/lib/decidim/reporting_proposals.rb
+++ b/lib/decidim/reporting_proposals.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "decidim/reporting_proposals/engine"
+require "decidim/reporting_proposals/component"
 
 module Decidim
   # This namespace holds the logic of the `decidim-reporting_proposals` module.

--- a/lib/decidim/reporting_proposals/component.rb
+++ b/lib/decidim/reporting_proposals/component.rb
@@ -1,0 +1,476 @@
+# frozen_string_literal: true
+
+require "decidim/components/namer"
+require "decidim/meetings"
+
+Decidim.register_component(:reporting_proposals) do |component|
+  component.engine = Decidim::Proposals::Engine
+  component.admin_engine = Decidim::Proposals::AdminEngine
+  component.stylesheet = "decidim/proposals/proposals"
+  component.icon = "media/images/decidim_proposals.svg"
+
+  component.on(:before_destroy) do |instance|
+    raise "Can't destroy this component when there are proposals" if Decidim::Proposals::Proposal.where(component: instance).any?
+  end
+
+  component.data_portable_entities = ["Decidim::Proposals::Proposal"]
+
+  component.newsletter_participant_entities = ["Decidim::Proposals::Proposal"]
+
+  component.actions = %w(endorse vote create withdraw amend comment vote_comment)
+
+  component.query_type = "Decidim::Proposals::ProposalsType"
+
+  component.permissions_class_name = "Decidim::Proposals::Permissions"
+
+  POSSIBLE_SORT_ORDERS = %w(default random recent most_endorsed most_voted most_commented most_followed with_more_authors).freeze
+
+  component.settings(:global) do |settings|
+    settings.attribute :scopes_enabled, type: :boolean, default: false
+    settings.attribute :scope_id, type: :scope
+    settings.attribute :vote_limit, type: :integer, default: 0
+    settings.attribute :minimum_votes_per_user, type: :integer, default: 0
+    settings.attribute :proposal_limit, type: :integer, default: 0
+    settings.attribute :proposal_length, type: :integer, default: 500
+    settings.attribute :proposal_edit_time, type: :enum, default: "limited", choices: -> { %w(limited infinite) }
+    settings.attribute :proposal_edit_before_minutes, type: :integer, default: 5
+    settings.attribute :threshold_per_proposal, type: :integer, default: 0
+    settings.attribute :can_accumulate_supports_beyond_threshold, type: :boolean, default: false
+    settings.attribute :proposal_answering_enabled, type: :boolean, default: true
+    settings.attribute :default_sort_order, type: :select, default: "default", choices: -> { POSSIBLE_SORT_ORDERS }
+    settings.attribute :official_proposals_enabled, type: :boolean, default: true
+    settings.attribute :comments_enabled, type: :boolean, default: true
+    settings.attribute :comments_max_length, type: :integer, required: false
+    settings.attribute :geocoding_enabled, type: :boolean, default: true
+    settings.attribute :attachments_allowed, type: :boolean, default: true
+    settings.attribute :resources_permissions_enabled, type: :boolean, default: true
+    settings.attribute :collaborative_drafts_enabled, type: :boolean, default: false, readonly: ->(_) { true }
+    settings.attribute :participatory_texts_enabled,
+                       type: :boolean, default: false,
+                       readonly: ->(_) { true }
+    settings.attribute :amendments_enabled, type: :boolean, default: false
+    settings.attribute :amendments_wizard_help_text, type: :text, translated: true, editor: true, required: false
+    settings.attribute :announcement, type: :text, translated: true, editor: true
+    settings.attribute :new_proposal_body_template, type: :text, translated: true, editor: true, required: false
+    settings.attribute :new_proposal_help_text, type: :text, translated: true, editor: true
+    settings.attribute :proposal_wizard_step_1_help_text, type: :text, translated: true, editor: true
+    settings.attribute :proposal_wizard_step_2_help_text, type: :text, translated: true, editor: true
+    settings.attribute :proposal_wizard_step_3_help_text, type: :text, translated: true, editor: true, readonly: ->(_) { true }
+    settings.attribute :proposal_wizard_step_4_help_text, type: :text, translated: true, editor: true
+  end
+
+  component.settings(:step) do |settings|
+    settings.attribute :endorsements_enabled, type: :boolean, default: true
+    settings.attribute :endorsements_blocked, type: :boolean
+    settings.attribute :votes_enabled, type: :boolean
+    settings.attribute :votes_blocked, type: :boolean
+    settings.attribute :votes_hidden, type: :boolean, default: false
+    settings.attribute :comments_blocked, type: :boolean, default: false
+    settings.attribute :creation_enabled, type: :boolean, default: true
+    settings.attribute :proposal_answering_enabled, type: :boolean, default: true
+    settings.attribute :publish_answers_immediately, type: :boolean, default: true
+    settings.attribute :answers_with_costs, type: :boolean, default: false
+    settings.attribute :default_sort_order, type: :select, include_blank: true, choices: -> { POSSIBLE_SORT_ORDERS }
+    settings.attribute :amendment_creation_enabled, type: :boolean, default: true
+    settings.attribute :amendment_reaction_enabled, type: :boolean, default: true
+    settings.attribute :amendment_promotion_enabled, type: :boolean, default: true
+    settings.attribute :amendments_visibility,
+                       type: :enum, default: "all",
+                       choices: -> { Decidim.config.amendments_visibility_options }
+    settings.attribute :announcement, type: :text, translated: true, editor: true
+    settings.attribute :automatic_hashtags, type: :text, editor: false, required: false
+    settings.attribute :suggested_hashtags, type: :text, editor: false, required: false
+  end
+
+  component.register_resource(:proposal) do |resource|
+    resource.model_class_name = "Decidim::Proposals::Proposal"
+    resource.template = "decidim/proposals/proposals/linked_proposals"
+    resource.card = "decidim/proposals/proposal"
+    resource.reported_content_cell = "decidim/proposals/reported_content"
+    resource.actions = %w(endorse vote amend comment vote_comment)
+    resource.searchable = true
+  end
+
+  component.register_resource(:collaborative_draft) do |resource|
+    resource.model_class_name = "Decidim::Proposals::CollaborativeDraft"
+    resource.card = "decidim/proposals/collaborative_draft"
+    resource.reported_content_cell = "decidim/proposals/collaborative_drafts/reported_content"
+  end
+
+  component.register_stat :proposals_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, start_at, end_at|
+    Decidim::Proposals::FilteredProposals.for(components, start_at, end_at).published.except_withdrawn.not_hidden.count
+  end
+
+  component.register_stat :proposals_accepted, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, start_at, end_at|
+    Decidim::Proposals::FilteredProposals.for(components, start_at, end_at).accepted.not_hidden.count
+  end
+
+  component.register_stat :supports_count, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, start_at, end_at|
+    proposals = Decidim::Proposals::FilteredProposals.for(components, start_at, end_at).published.not_hidden
+    Decidim::Proposals::ProposalVote.where(proposal: proposals).count
+  end
+
+  component.register_stat :endorsements_count, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |components, start_at, end_at|
+    proposals = Decidim::Proposals::FilteredProposals.for(components, start_at, end_at).not_hidden
+    proposals.sum(:endorsements_count)
+  end
+
+  component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+    proposals = Decidim::Proposals::FilteredProposals.for(components, start_at, end_at).published.not_hidden
+    proposals.sum(:comments_count)
+  end
+
+  component.register_stat :followers_count, tag: :followers, priority: Decidim::StatsRegistry::LOW_PRIORITY do |components, start_at, end_at|
+    proposals_ids = Decidim::Proposals::FilteredProposals.for(components, start_at, end_at).published.not_hidden.pluck(:id)
+    Decidim::Follow.where(decidim_followable_type: "Decidim::Proposals::Proposal", decidim_followable_id: proposals_ids).count
+  end
+
+  component.exports :proposals do |exports|
+    exports.collection do |component_instance, user|
+      space = component_instance.participatory_space
+
+      collection = Decidim::Proposals::Proposal
+                   .published
+                   .where(component: component_instance)
+                   .includes(:scope, :category, :component)
+
+      if space.user_roles(:valuator).where(user: user).any?
+        collection.with_valuation_assigned_to(user, space)
+      else
+        collection
+      end
+    end
+
+    exports.include_in_open_data = true
+
+    exports.serializer Decidim::Proposals::ProposalSerializer
+  end
+
+  component.exports :proposal_comments do |exports|
+    exports.collection do |component_instance|
+      Decidim::Comments::Export.comments_for_resource(
+        Decidim::Proposals::Proposal, component_instance
+      ).includes(:author, :user_group, root_commentable: { component: { participatory_space: :organization } })
+    end
+
+    exports.include_in_open_data = true
+
+    exports.serializer Decidim::Comments::CommentSerializer
+  end
+
+  component.imports :proposals do |imports|
+    imports.form_view = "decidim/proposals/admin/imports/proposals_fields"
+    imports.form_class_name = "Decidim::Proposals::Admin::ProposalsFileImportForm"
+
+    imports.messages do |msg|
+      msg.set(:resource_name) { |count: 1| I18n.t("decidim.proposals.admin.imports.resources.proposals", count: count) }
+      msg.set(:title) { I18n.t("decidim.proposals.admin.imports.title.proposals") }
+      msg.set(:label) { I18n.t("decidim.proposals.admin.imports.label.proposals") }
+      msg.set(:help) { I18n.t("decidim.proposals.admin.imports.help.proposals") }
+    end
+
+    imports.creator Decidim::Proposals::Import::ProposalCreator
+  end
+
+  component.imports :answers do |imports|
+    imports.messages do |msg|
+      msg.set(:resource_name) { |count: 1| I18n.t("decidim.proposals.admin.imports.resources.answers", count: count) }
+      msg.set(:title) { I18n.t("decidim.proposals.admin.imports.title.answers") }
+      msg.set(:label) { I18n.t("decidim.proposals.admin.imports.label.answers") }
+      msg.set(:help) { I18n.t("decidim.proposals.admin.imports.help.answers") }
+    end
+
+    imports.creator Decidim::Proposals::Import::ProposalAnswerCreator
+    imports.example do |import_component|
+      organization = import_component.organization
+      [
+        %w(id state) + organization.available_locales.map { |l| "answer/#{l}" },
+        [1, "accepted"] + organization.available_locales.map { "Example answer" },
+        [2, "rejected"] + organization.available_locales.map { "Example answer" },
+        [3, "evaluating"] + organization.available_locales.map { "Example answer" }
+      ]
+    end
+  end
+
+  component.seeds do |participatory_space|
+    admin_user = Decidim::User.find_by(
+      organization: participatory_space.organization,
+      email: "admin@example.org"
+    )
+
+    step_settings = if participatory_space.allows_steps?
+                      { participatory_space.active_step.id => { votes_enabled: true, votes_blocked: false, creation_enabled: true } }
+                    else
+                      {}
+                    end
+
+    params = {
+      name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :reporting_proposals).i18n_name,
+      manifest_name: :reporting_proposals,
+      published_at: Time.current,
+      participatory_space: participatory_space,
+      settings: {
+        vote_limit: 0,
+        collaborative_drafts_enabled: true
+      },
+      step_settings: step_settings
+    }
+
+    component = Decidim.traceability.perform_action!(
+      "publish",
+      Decidim::Component,
+      admin_user,
+      visibility: "all"
+    ) do
+      Decidim::Component.create!(params)
+    end
+
+    if participatory_space.scope
+      scopes = participatory_space.scope.descendants
+      global = participatory_space.scope
+    else
+      scopes = participatory_space.organization.scopes
+      global = nil
+    end
+
+    5.times do |n|
+      state, answer, state_published_at = if n > 3
+                                            ["accepted", Decidim::Faker::Localized.sentence(word_count: 10), Time.current]
+                                          elsif n > 2
+                                            ["rejected", nil, Time.current]
+                                          elsif n > 1
+                                            ["evaluating", nil, Time.current]
+                                          elsif n.positive?
+                                            ["accepted", Decidim::Faker::Localized.sentence(word_count: 10), nil]
+                                          else
+                                            [nil, nil, nil]
+                                          end
+
+      params = {
+        component: component,
+        category: participatory_space.categories.sample,
+        scope: Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,
+        title: { en: Faker::Lorem.sentence(word_count: 2) },
+        body: { en: Faker::Lorem.paragraphs(number: 2).join("\n") },
+        state: state,
+        answer: answer,
+        answered_at: state.present? ? Time.current : nil,
+        state_published_at: state_published_at,
+        published_at: Time.current
+      }
+
+      proposal = Decidim.traceability.perform_action!(
+        "publish",
+        Decidim::Proposals::Proposal,
+        admin_user,
+        visibility: "all"
+      ) do
+        proposal = Decidim::Proposals::Proposal.new(params)
+        proposal.add_coauthor(participatory_space.organization)
+        proposal.save!
+        proposal
+      end
+
+      if n.positive?
+        Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample(n).each do |author|
+          user_group = [true, false].sample ? Decidim::UserGroups::ManageableUserGroups.for(author).verified.sample : nil
+          proposal.add_coauthor(author, user_group: user_group)
+        end
+      end
+
+      if proposal.state.nil?
+        email = "amendment-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{n}-amend#{n}@example.org"
+        name = "#{Faker::Name.name} #{participatory_space.id} #{n} amend#{n}"
+
+        author = Decidim::User.find_or_initialize_by(email: email)
+        author.update!(
+          password: "decidim123456",
+          password_confirmation: "decidim123456",
+          name: name,
+          nickname: Faker::Twitter.unique.screen_name,
+          organization: component.organization,
+          tos_agreement: "1",
+          confirmed_at: Time.current
+        )
+
+        group = Decidim::UserGroup.create!(
+          name: Faker::Name.name,
+          nickname: Faker::Twitter.unique.screen_name,
+          email: Faker::Internet.email,
+          extended_data: {
+            document_number: Faker::Code.isbn,
+            phone: Faker::PhoneNumber.phone_number,
+            verified_at: Time.current
+          },
+          decidim_organization_id: component.organization.id,
+          confirmed_at: Time.current
+        )
+
+        Decidim::UserGroupMembership.create!(
+          user: author,
+          role: "creator",
+          user_group: group
+        )
+
+        params = {
+          component: component,
+          category: participatory_space.categories.sample,
+          scope: Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,
+          title: { en: "#{proposal.title["en"]} #{Faker::Lorem.sentence(word_count: 1)}" },
+          body: { en: "#{proposal.body["en"]} #{Faker::Lorem.sentence(word_count: 3)}" },
+          state: "evaluating",
+          answer: nil,
+          answered_at: Time.current,
+          published_at: Time.current
+        }
+
+        emendation = Decidim.traceability.perform_action!(
+          "create",
+          Decidim::Proposals::Proposal,
+          author,
+          visibility: "public-only"
+        ) do
+          emendation = Decidim::Proposals::Proposal.new(params)
+          emendation.add_coauthor(author, user_group: author.user_groups.first)
+          emendation.save!
+          emendation
+        end
+
+        Decidim::Amendment.create!(
+          amender: author,
+          amendable: proposal,
+          emendation: emendation,
+          state: "evaluating"
+        )
+      end
+
+      (n % 3).times do |m|
+        email = "vote-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{n}-#{m}@example.org"
+        name = "#{Faker::Name.name} #{participatory_space.id} #{n} #{m}"
+
+        author = Decidim::User.find_or_initialize_by(email: email)
+        author.update!(
+          password: "decidim123456",
+          password_confirmation: "decidim123456",
+          name: name,
+          nickname: Faker::Twitter.unique.screen_name,
+          organization: component.organization,
+          tos_agreement: "1",
+          confirmed_at: Time.current,
+          personal_url: Faker::Internet.url,
+          about: Faker::Lorem.paragraph(sentence_count: 2)
+        )
+
+        Decidim::Proposals::ProposalVote.create!(proposal: proposal, author: author) unless proposal.published_state? && proposal.rejected?
+        Decidim::Proposals::ProposalVote.create!(proposal: emendation, author: author) if emendation
+      end
+
+      unless proposal.published_state? && proposal.rejected?
+        (n * 2).times do |index|
+          email = "endorsement-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{n}-endr#{index}@example.org"
+          name = "#{Faker::Name.name} #{participatory_space.id} #{n} endr#{index}"
+
+          author = Decidim::User.find_or_initialize_by(email: email)
+          author.update!(
+            password: "decidim123456",
+            password_confirmation: "decidim123456",
+            name: name,
+            nickname: Faker::Twitter.unique.screen_name,
+            organization: component.organization,
+            tos_agreement: "1",
+            confirmed_at: Time.current
+          )
+          if index.even?
+            group = Decidim::UserGroup.create!(
+              name: Faker::Name.name,
+              nickname: Faker::Twitter.unique.screen_name,
+              email: Faker::Internet.email,
+              extended_data: {
+                document_number: Faker::Code.isbn,
+                phone: Faker::PhoneNumber.phone_number,
+                verified_at: Time.current
+              },
+              decidim_organization_id: component.organization.id,
+              confirmed_at: Time.current
+            )
+
+            Decidim::UserGroupMembership.create!(
+              user: author,
+              role: "creator",
+              user_group: group
+            )
+          end
+          Decidim::Endorsement.create!(resource: proposal, author: author, user_group: author.user_groups.first)
+        end
+      end
+
+      (n % 3).times do
+        author_admin = Decidim::User.where(organization: component.organization, admin: true).all.sample
+
+        Decidim::Proposals::ProposalNote.create!(
+          proposal: proposal,
+          author: author_admin,
+          body: Faker::Lorem.paragraphs(number: 2).join("\n")
+        )
+      end
+
+      Decidim::Comments::Seed.comments_for(proposal)
+
+      #
+      # Collaborative drafts
+      #
+      state = if n > 3
+                "published"
+              elsif n > 2
+                "withdrawn"
+              else
+                "open"
+              end
+      author = Decidim::User.where(organization: component.organization).all.sample
+
+      draft = Decidim.traceability.perform_action!("create", Decidim::Proposals::CollaborativeDraft, author) do
+        draft = Decidim::Proposals::CollaborativeDraft.new(
+          component: component,
+          category: participatory_space.categories.sample,
+          scope: Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,
+          title: Faker::Lorem.sentence(word_count: 2),
+          body: Faker::Lorem.paragraphs(number: 2).join("\n"),
+          state: state,
+          published_at: Time.current
+        )
+        draft.coauthorships.build(author: participatory_space.organization)
+        draft.save!
+        draft
+      end
+
+      case n
+      when 2
+        author2 = Decidim::User.where(organization: component.organization).all.sample
+        Decidim::Coauthorship.create(coauthorable: draft, author: author2)
+        author3 = Decidim::User.where(organization: component.organization).all.sample
+        Decidim::Coauthorship.create(coauthorable: draft, author: author3)
+        author4 = Decidim::User.where(organization: component.organization).all.sample
+        Decidim::Coauthorship.create(coauthorable: draft, author: author4)
+        author5 = Decidim::User.where(organization: component.organization).all.sample
+        Decidim::Coauthorship.create(coauthorable: draft, author: author5)
+        author6 = Decidim::User.where(organization: component.organization).all.sample
+        Decidim::Coauthorship.create(coauthorable: draft, author: author6)
+      when 3
+        author2 = Decidim::User.where(organization: component.organization).all.sample
+        Decidim::Coauthorship.create(coauthorable: draft, author: author2)
+      end
+
+      Decidim::Comments::Seed.comments_for(draft)
+    end
+
+    Decidim.traceability.update!(
+      Decidim::Proposals::CollaborativeDraft.all.sample,
+      Decidim::User.where(organization: component.organization).all.sample,
+      component: component,
+      category: participatory_space.categories.sample,
+      scope: Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,
+      title: Faker::Lorem.sentence(word_count: 2),
+      body: Faker::Lorem.paragraphs(number: 2).join("\n")
+    )
+  end
+end

--- a/lib/decidim/reporting_proposals/component.rb
+++ b/lib/decidim/reporting_proposals/component.rb
@@ -23,7 +23,7 @@ Decidim.register_component(:reporting_proposals) do |component|
 
   component.permissions_class_name = "Decidim::Proposals::Permissions"
 
-  POSSIBLE_SORT_ORDERS = %w(default random recent most_endorsed most_voted most_commented most_followed with_more_authors).freeze
+  REP_POSSIBLE_SORT_ORDERS = %w(default random recent most_endorsed most_voted most_commented most_followed with_more_authors).freeze
 
   component.settings(:global) do |settings|
     settings.attribute :scopes_enabled, type: :boolean, default: false
@@ -37,7 +37,7 @@ Decidim.register_component(:reporting_proposals) do |component|
     settings.attribute :threshold_per_proposal, type: :integer, default: 0
     settings.attribute :can_accumulate_supports_beyond_threshold, type: :boolean, default: false
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
-    settings.attribute :default_sort_order, type: :select, default: "default", choices: -> { POSSIBLE_SORT_ORDERS }
+    settings.attribute :default_sort_order, type: :select, default: "default", choices: -> { REP_POSSIBLE_SORT_ORDERS }
     settings.attribute :official_proposals_enabled, type: :boolean, default: true
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :comments_max_length, type: :integer, required: false
@@ -70,7 +70,7 @@ Decidim.register_component(:reporting_proposals) do |component|
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
     settings.attribute :publish_answers_immediately, type: :boolean, default: true
     settings.attribute :answers_with_costs, type: :boolean, default: false
-    settings.attribute :default_sort_order, type: :select, include_blank: true, choices: -> { POSSIBLE_SORT_ORDERS }
+    settings.attribute :default_sort_order, type: :select, include_blank: true, choices: -> { REP_POSSIBLE_SORT_ORDERS }
     settings.attribute :amendment_creation_enabled, type: :boolean, default: true
     settings.attribute :amendment_reaction_enabled, type: :boolean, default: true
     settings.attribute :amendment_promotion_enabled, type: :boolean, default: true

--- a/lib/decidim/reporting_proposals/engine.rb
+++ b/lib/decidim/reporting_proposals/engine.rb
@@ -7,7 +7,8 @@ module Decidim
       isolate_namespace Decidim::ReportingProposals
 
       # overrides for proposals
-      config.to_prepare do
+      config.after_initialize do
+        Decidim::Admin::ComponentsController.include(Decidim::ReportingProposals::Admin::NeedsHeaderSnippets)
         Decidim::Proposals::ProposalsController.include(Decidim::ReportingProposals::ProposalsControllerOverride)
         Decidim::Proposals::ProposalWizardHelper.include(Decidim::ReportingProposals::ProposalWizardHelperOverride)
         ComponentValidator.include(Decidim::ReportingProposals::ComponentValidatorOverride)

--- a/lib/decidim/reporting_proposals/engine.rb
+++ b/lib/decidim/reporting_proposals/engine.rb
@@ -6,6 +6,12 @@ module Decidim
     class Engine < ::Rails::Engine
       isolate_namespace Decidim::ReportingProposals
 
+      # overrides for proposals
+      config.to_prepare do
+        Decidim::Proposals::ProposalsController.include(Decidim::ReportingProposals::ProposalsControllerOverride)
+        Decidim::Proposals::ProposalWizardHelper.include(Decidim::ReportingProposals::ProposalWizardHelperOverride)
+      end
+
       initializer "decidim_reporting_proposals.webpacker.assets_path" do
         Decidim.register_assets_path File.expand_path("app/packs", root)
       end

--- a/lib/decidim/reporting_proposals/engine.rb
+++ b/lib/decidim/reporting_proposals/engine.rb
@@ -10,6 +10,7 @@ module Decidim
       config.to_prepare do
         Decidim::Proposals::ProposalsController.include(Decidim::ReportingProposals::ProposalsControllerOverride)
         Decidim::Proposals::ProposalWizardHelper.include(Decidim::ReportingProposals::ProposalWizardHelperOverride)
+        ComponentValidator.include(Decidim::ReportingProposals::ComponentValidatorOverride)
       end
 
       initializer "decidim_reporting_proposals.webpacker.assets_path" do

--- a/lib/decidim/reporting_proposals/test/factories.rb
+++ b/lib/decidim/reporting_proposals/test/factories.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :reporting_proposals_component, parent: :proposal_component do
+    name { Decidim::Components::Namer.new(participatory_space.organization.available_locales, :reporting_proposals).i18n_name }
+    manifest_name { :reporting_proposals }
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
 require "decidim/core/test/factories"
+require "decidim/participatory_processes/test/factories"
+require "decidim/proposals/test/factories"
+require "decidim/reporting_proposals/test/factories"

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# We make sure that the checksum of the file overriden is the same
+# as the expected. If this test fails, it means that the overriden
+# file should be updated to match any change/bug fix introduced in the core
+checksums = [
+  {
+    package: "decidim-proposals",
+    files: {
+      "/app/controllers/decidim/proposals/proposals_controller.rb" => "6f73c3cad3c713358535c92e2ed84f60",
+      "/app/helpers/decidim/proposals/proposal_wizard_helper.rb" => "75d875f3323e75273819d526731140da"
+    }
+  }
+]
+
+describe "Overriden files", type: :view do
+  checksums.each do |item|
+    # rubocop:disable Rails/DynamicFindBy
+    spec = ::Gem::Specification.find_by_name(item[:package])
+    # rubocop:enable Rails/DynamicFindBy
+    item[:files].each do |file, signature|
+      it "#{spec.gem_dir}#{file} matches checksum" do
+        expect(md5("#{spec.gem_dir}#{file}")).to eq(signature)
+      end
+    end
+  end
+
+  private
+
+  def md5(file)
+    Digest::MD5.hexdigest(File.read(file))
+  end
+end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -7,6 +7,12 @@ require "spec_helper"
 # file should be updated to match any change/bug fix introduced in the core
 checksums = [
   {
+    package: "decidim-core",
+    files: {
+      "/lib/decidim/component_validator.rb" => "2e3eb588a9579b94c21f4f440751d9a9"
+    }
+  },
+  {
     package: "decidim-proposals",
     files: {
       "/app/controllers/decidim/proposals/proposals_controller.rb" => "6f73c3cad3c713358535c92e2ed84f60",

--- a/spec/system/admin/manage_reporting_proposals_component_spec.rb
+++ b/spec/system/admin/manage_reporting_proposals_component_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Managing reporting proposals component", type: :system do
+  let(:organization) { create :organization }
+  let(:participatory_process) { create :participatory_process, organization: organization }
+  let!(:component) { create :reporting_proposals_component, participatory_space: participatory_process }
+  let!(:user) { create(:user, :confirmed, :admin, organization: organization) }
+
+  def edit_component_path(component)
+    Decidim::EngineRouter.admin_proxy(component.participatory_space).edit_component_path(component.id)
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+
+    visit edit_component_path(component)
+  end
+
+  it "hides readonly attributes" do
+    expect(page).not_to have_content("Collaborative drafts enabled")
+    expect(page).not_to have_content("Participatory texts enabled")
+  end
+
+  context "when managing standard proposals" do
+    let!(:component) { create :proposal_component, participatory_space: participatory_process }
+
+    it "does not hide readonly attributes" do
+      expect(page).to have_content("Collaborative drafts enabled")
+      expect(page).to have_content("Participatory texts enabled")
+    end
+  end
+end

--- a/spec/system/reporting_proposals_spec.rb
+++ b/spec/system/reporting_proposals_spec.rb
@@ -7,6 +7,8 @@ describe "Reporting proposals overrides", type: :system do
   let(:manifest_name) { "reporting_proposals" }
   let!(:component) { create(:reporting_proposals_component, participatory_space: participatory_process) }
   let!(:user) { create(:user, :confirmed, organization: organization) }
+  let(:proposal_title) { "More sidewalks and less roads" }
+  let(:proposal_body) { "Cities need more people, not more cars" }
 
   before do
     switch_to_host(organization.host)
@@ -22,6 +24,24 @@ describe "Reporting proposals overrides", type: :system do
         expect(page).not_to have_content("Complete")
       end
     end
+
+    it "redirects to the plublish action" do
+      click_link "New proposal"
+
+      within ".card__content form" do
+        fill_in :proposal_title, with: proposal_title
+        fill_in :proposal_body, with: proposal_body
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_content(proposal_title)
+      expect(page).to have_content(user.name)
+      expect(page).to have_content(proposal_body)
+
+      expect(page).to have_selector("button", text: "Publish")
+
+      expect(page).to have_selector("a", text: "Modify the proposal")
+    end
   end
 
   shared_examples "4 steps" do
@@ -32,6 +52,22 @@ describe "Reporting proposals overrides", type: :system do
       within ".wizard__steps" do
         expect(page).to have_content("Complete")
       end
+    end
+
+    it "redirects to the complete action" do
+      click_link "New proposal"
+
+      within ".card__content form" do
+        fill_in :proposal_title, with: proposal_title
+        fill_in :proposal_body, with: proposal_body
+        find("*[type=submit]").click
+      end
+
+      within ".section-heading" do
+        expect(page).to have_content("COMPLETE YOUR PROPOSAL")
+      end
+
+      expect(page).to have_css(".edit_proposal")
     end
   end
 

--- a/spec/system/reporting_proposals_spec.rb
+++ b/spec/system/reporting_proposals_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Reporting proposals overrides", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "reporting_proposals" }
+  let!(:component) { create(:reporting_proposals_component, participatory_space: participatory_process) }
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  shared_examples "3 steps" do
+    it "sidebar does not have the complete step" do
+      click_link "New proposal"
+
+      expect(page).to have_content("Step 1 of 3")
+      within ".wizard__steps" do
+        expect(page).not_to have_content("Complete")
+      end
+    end
+  end
+
+  shared_examples "4 steps" do
+    it "sidebar has the complete step" do
+      click_link "New proposal"
+
+      expect(page).to have_content("Step 1 of 4")
+      within ".wizard__steps" do
+        expect(page).to have_content("Complete")
+      end
+    end
+  end
+
+  context "when creating a new proposal" do
+    before do
+      visit_component
+    end
+
+    it_behaves_like "3 steps"
+  end
+
+  context "and component is a normal proposal" do
+    let(:manifest_name) { "proposals" }
+    let!(:component) { create(:proposal_component, :with_creation_enabled, participatory_space: participatory_process) }
+
+    before do
+      visit_component
+    end
+
+    it_behaves_like "4 steps"
+  end
+end


### PR DESCRIPTION
Adds a new component for participatory spaces, based on proposals "reporting proposals".

This component behaves exactly equal as the proposals with some changes:

- [x] Participatory texts are disabled
- [x] Collaborative drafts are disabled
- [x] Geolocation is enabled by default
- [x] Proposal creation is enabled by default

![image](https://user-images.githubusercontent.com/1401520/189706525-2e343a01-cc2b-4d42-a198-82bb518c1e58.png)

![image](https://user-images.githubusercontent.com/1401520/189706396-39cba7a7-386f-48df-8c26-8eecd1e70c49.png)

fixes #3 