### PR TITLE
Add "image from camera" button in file uploads

### DIFF
--- a/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
+++ b/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ReportingProposals
+    module FormBuilderOverride
+      extend ActiveSupport::Concern
+      include Decidim::LayoutHelper
+
+      # These methods are used in deeper levels and might not be available in this context when this is called, thus the delegation
+      delegate :asset_pack_path, to: :@template
+
+      included do
+        def file_field(object_name, method, options = {})
+          unless @template.snippets.any?(:reporting_proposals_camera_addons) || !user_camera_button?
+            @template.snippets.add(:reporting_proposals_camera_addons, @template.javascript_pack_tag("decidim_reporting_proposals_camera"))
+            @template.snippets.add(:reporting_proposals_camera_addons, @template.stylesheet_pack_tag("decidim_reporting_proposals_camera"))
+
+            # This will display the snippets in the <head> part of the page.
+            @template.snippets.add(:head, @template.snippets.for(:reporting_proposals_camera_addons))
+          end
+
+          content_tag(:div, class: "input-group") do
+            super(object_name, method, options) +
+              content_tag(:div, class: "input-group-button") do
+                content_tag(:button, class: "button secondary user-device-camera", type: "button", data: { input: "#{object_name}_#{method}" }) do
+                  icon("camera-slr", role: "img", "aria-hidden": true) + " #{I18n.t("use_my_camera", scope: "decidim.reporting_proposals.forms")}"
+                end
+              end
+          end
+        end
+
+        private
+
+        def user_camera_button?
+          return unless @template.respond_to?(:current_component)
+
+          Decidim::ReportingProposals.use_camera_button.include?(@template.current_component.manifest_name.to_sym)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
+++ b/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
@@ -11,7 +11,9 @@ module Decidim
 
       included do
         def file_field(object_name, method, options = {})
-          unless @template.snippets.any?(:reporting_proposals_camera_addons) || !user_camera_button?
+          return super(object_name, method, options) unless use_camera_button?(object_name)
+
+          unless @template.snippets.any?(:reporting_proposals_camera_addons)
             @template.snippets.add(:reporting_proposals_camera_addons, @template.javascript_pack_tag("decidim_reporting_proposals_camera"))
             @template.snippets.add(:reporting_proposals_camera_addons, @template.stylesheet_pack_tag("decidim_reporting_proposals_camera"))
 
@@ -31,10 +33,14 @@ module Decidim
 
         private
 
-        def user_camera_button?
+        def use_camera_button?(object_name)
           return unless @template.respond_to?(:current_component)
 
-          Decidim::ReportingProposals.use_camera_button.include?(@template.current_component.manifest_name.to_sym)
+          return unless Decidim::ReportingProposals.use_camera_button.include?(@template.current_component.manifest_name.to_sym)
+
+          return object_name == :add_photos unless Decidim::ReportingProposals.camera_button_on_attachments
+
+          true
         end
       end
     end

--- a/app/forms/decidim/reporting_proposals/proposal_form.rb
+++ b/app/forms/decidim/reporting_proposals/proposal_form.rb
@@ -5,11 +5,14 @@ module Decidim
     class ProposalForm < Decidim::Proposals::ProposalForm
       attribute :address, String
       attribute :has_no_address, Boolean
+      attribute :has_no_image, Boolean
 
-      def has_address?
-        return if has_no_address
+      validates :add_photos, presence: true, if: ->(form) { form.has_camera? }
 
-        geocoding_enabled?
+      def has_camera?
+        return if has_no_image
+
+        current_component.settings.attachments_allowed?
       end
     end
   end

--- a/app/forms/decidim/reporting_proposals/proposal_form.rb
+++ b/app/forms/decidim/reporting_proposals/proposal_form.rb
@@ -9,6 +9,12 @@ module Decidim
 
       validates :add_photos, presence: true, if: ->(form) { form.has_camera? }
 
+      def has_address?
+        return if has_no_address
+
+        geocoding_enabled?
+      end
+
       def has_camera?
         return if has_no_image
 

--- a/app/packs/entrypoints/decidim_reporting_proposals_camera.js
+++ b/app/packs/entrypoints/decidim_reporting_proposals_camera.js
@@ -1,0 +1,2 @@
+import "src/decidim/reporting_proposals/user_camera_inputs.js"
+import "stylesheets/decidim/reporting_proposals/user_camera_inputs.scss";

--- a/app/packs/src/decidim/reporting_proposals/user_camera_inputs.js
+++ b/app/packs/src/decidim/reporting_proposals/user_camera_inputs.js
@@ -1,4 +1,29 @@
 $(() => {
-  $("#proposal_add_photos").attr("capture", "camera");
-  $("#proposal_add_photos").attr("accept", "image/*");
+  $('input[type="file"]').each((_i, el) => {
+    const $input = $(el);
+    const $inputField = $input.closest(".row.column");
+    const $button = $inputField.find("button:first");
+    const $checkbox = $inputField.find("input:checkbox[name$='[has_no_image]']");
+
+    $input.attr("capture", "camera");
+    $input.attr("accept", "image/*");
+
+    $button.on("click", () => {
+      $input.click();
+    });
+
+    if ($checkbox.length > 0) {
+      const toggleInput = () => {
+        console.log("toggleInput", $checkbox)
+        if ($checkbox[0].checked) {
+          $input.prop("disabled", true);
+          $button.prop("disabled", true);
+        } else {
+          $input.prop("disabled", false);
+          $button.prop("disabled", false);
+        }
+      }
+      $checkbox.on("change", toggleInput);
+    }
+  });
 }); 

--- a/app/packs/src/decidim/reporting_proposals/user_camera_inputs.js
+++ b/app/packs/src/decidim/reporting_proposals/user_camera_inputs.js
@@ -1,0 +1,4 @@
+$(() => {
+  $("#proposal_add_photos").attr("capture", "camera");
+  $("#proposal_add_photos").attr("accept", "image/*");
+}); 

--- a/app/packs/src/decidim/reporting_proposals/user_camera_inputs.js
+++ b/app/packs/src/decidim/reporting_proposals/user_camera_inputs.js
@@ -14,7 +14,6 @@ $(() => {
 
     if ($checkbox.length > 0) {
       const toggleInput = () => {
-        console.log("toggleInput", $checkbox)
         if ($checkbox[0].checked) {
           $input.prop("disabled", true);
           $button.prop("disabled", true);

--- a/app/packs/stylesheets/decidim/reporting_proposals/user_camera_inputs.scss
+++ b/app/packs/stylesheets/decidim/reporting_proposals/user_camera_inputs.scss
@@ -1,0 +1,8 @@
+button.user-device-camera {
+  border-radius: 4px !important;
+}
+
+.has_no_image {
+  margin-top: -1rem;
+  text-align: right;
+}

--- a/app/packs/stylesheets/decidim/reporting_proposals/user_camera_inputs.scss
+++ b/app/packs/stylesheets/decidim/reporting_proposals/user_camera_inputs.scss
@@ -1,5 +1,6 @@
 button.user-device-camera {
   border-radius: 4px !important;
+  max-height: 3rem;
 }
 
 .has_no_image {

--- a/app/views/decidim/reporting_proposals/proposals/_reporting_proposal_fields.html.erb
+++ b/app/views/decidim/reporting_proposals/proposals/_reporting_proposal_fields.html.erb
@@ -5,35 +5,17 @@
 <% end %>
 
 <% if component_settings.attachments_allowed? %>
-  <fieldset class="gallery__container photos_container">
-    <legend><%= t("gallery_legend", scope: "decidim.proposals.proposals.edit") %></legend>
+    <div class="field row column">
+      <%= form.file_field :add_photos, multiple: false, label: t("add_images", scope: "decidim.reporting_proposals.proposals.form") %>
 
-    <% if @form.photos.any? %>
-      <% @form.photos.each do |photo| %>
-        <div class="callout gallery__item" id="attachment_<%= photo.id %>" data-closable>
-          <%= image_tag photo.thumbnail_url, class: "thumbnail", alt: photo.file.filename %>
-          <%= form.hidden_field :photos, multiple: true, value: photo.id, id: "photo-#{photo.id}" %>
-          <button class="close-button"
-                  aria-label="<%= t("delete_image", scope: "decidim.proposals.proposals.edit") %>"
-                  title="<%= t("delete_image", scope: "decidim.proposals.proposals.edit") %>"
-                  type="button"
-                  data-close>
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-      <% end %>
-    <% end %>
-
-    <div class="row column">
-      <%= form.file_field :add_photos, multiple: false, label: t("add_images", scope: "decidim.proposals.proposals.edit") %>
+      <div class="has_no_image">
+        <%= form.check_box :has_no_image %>
+      </div>
     </div>
-  </fieldset>
+
 <% end %>
 
 <% if @form.geocoding_enabled? %>
-  <div class="field">
-  </div>
-
   <div class="field" id="address_input">
     <div class="address-fill">
       <%= form.geocoding_field :address, placeholder: t("decidim.proposals.proposals.placeholder.address") %>

--- a/app/views/decidim/reporting_proposals/proposals/_reporting_proposal_fields.html.erb
+++ b/app/views/decidim/reporting_proposals/proposals/_reporting_proposal_fields.html.erb
@@ -6,7 +6,7 @@
 
 <% if component_settings.attachments_allowed? %>
     <div class="field row column">
-      <%= form.file_field :add_photos, multiple: false, label: t("add_images", scope: "decidim.reporting_proposals.proposals.form") %>
+      <%= form.file_field :add_photos, multiple: false, label: t("image", scope: "decidim.reporting_proposals.proposals.form") %>
 
       <div class="has_no_image">
         <%= form.check_box :has_no_image %>
@@ -69,7 +69,7 @@
   </div>
 <% end %>
 
-<% if component_settings.attachments_allowed? %>
+<% if component_settings.attachments_allowed? && !component_settings.only_photo_attachments? %>
   <fieldset class="attachments_container gallery__container documents_container">
     <legend><%= t("attachment_legend", scope: "decidim.proposals.proposals.edit") %></legend>
 

--- a/config/assets.rb
+++ b/config/assets.rb
@@ -7,5 +7,6 @@ Decidim::Webpacker.register_entrypoints(
   decidim_reporting_proposals: "#{base_path}/app/packs/entrypoints/decidim_reporting_proposals.js",
   decidim_reporting_proposals_manage_component_admin: "#{base_path}/app/packs/entrypoints/decidim_reporting_proposals_manage_component_admin.js",
   decidim_reporting_proposals_list_component_admin: "#{base_path}/app/packs/entrypoints/decidim_reporting_proposals_list_component_admin.js",
-  decidim_reporting_proposals_geocoding: "#{base_path}/app/packs/entrypoints/decidim_reporting_proposals_geocoding.js"
+  decidim_reporting_proposals_geocoding: "#{base_path}/app/packs/entrypoints/decidim_reporting_proposals_geocoding.js",
+  decidim_reporting_proposals_camera: "#{base_path}/app/packs/entrypoints/decidim_reporting_proposals_camera.js"
 )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -345,3 +345,8 @@ en:
           device_not_supported: Geolocation is not supported by your browser.
           no_device_location: Sorry, we couldn't detect your location.
         use_my_location: Use my location
+        use_my_camera: Use my camera
+      proposals:
+        form:
+          add_images: Add images
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
         name: Reporting proposals
         settings:
           global:
+            only_photo_attachments: Use only photo attachments
             amendments_enabled: Amendments enabled
             amendments_enabled_help: If active, configure Amendment features for each
               step.
@@ -348,5 +349,5 @@ en:
         use_my_camera: Use my camera
       proposals:
         form:
-          add_images: Add images
+          image: Image/photo
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,6 @@ en:
         name: Reporting proposals
         settings:
           global:
-            only_photo_attachments: Use only photo attachments
             amendments_enabled: Amendments enabled
             amendments_enabled_help: If active, configure Amendment features for each
               step.
@@ -60,6 +59,7 @@ en:
               new Proposals will have
             new_proposal_help_text: New proposal help text
             official_proposals_enabled: Official proposals enabled
+            only_photo_attachments: Use only photo attachments
             participatory_texts_enabled: Participatory texts enabled
             participatory_texts_enabled_readonly: Cannot interact with this setting
               if there are existing proposals. Please, create a new `Proposals component`
@@ -345,9 +345,8 @@ en:
         errors:
           device_not_supported: Geolocation is not supported by your browser.
           no_device_location: Sorry, we couldn't detect your location.
-        use_my_location: Use my location
         use_my_camera: Use my camera
+        use_my_location: Use my location
       proposals:
         form:
           image: Image/photo
-

--- a/lib/decidim/reporting_proposals/component.rb
+++ b/lib/decidim/reporting_proposals/component.rb
@@ -43,6 +43,7 @@ Decidim.register_component(:reporting_proposals) do |component|
     settings.attribute :comments_max_length, type: :integer, required: false
     settings.attribute :geocoding_enabled, type: :boolean, default: true
     settings.attribute :attachments_allowed, type: :boolean, default: true
+    settings.attribute :only_photo_attachments, type: :boolean, default: true
     settings.attribute :resources_permissions_enabled, type: :boolean, default: true
     settings.attribute :collaborative_drafts_enabled, type: :boolean, default: false, readonly: ->(_) { true }
     settings.attribute :participatory_texts_enabled,

--- a/lib/decidim/reporting_proposals/config.rb
+++ b/lib/decidim/reporting_proposals/config.rb
@@ -28,5 +28,9 @@ module Decidim
     config_accessor :show_my_location_button do
       [:proposals, :meetings, :reporting_proposals]
     end
+
+    config_accessor :use_camera_button do
+      [:proposals, :meetings, :reporting_proposals]
+    end
   end
 end

--- a/lib/decidim/reporting_proposals/config.rb
+++ b/lib/decidim/reporting_proposals/config.rb
@@ -29,8 +29,14 @@ module Decidim
       [:proposals, :meetings, :reporting_proposals]
     end
 
+    # Public Setting that adds a button next to the "add image" input[type=file] to open the camera directly
     config_accessor :use_camera_button do
-      [:proposals, :meetings, :reporting_proposals]
+      [:proposals, :reporting_proposals]
+    end
+
+    # Public Setting to prevent adding the camera button on not photo/image input[type=file]
+    config_accessor :camera_button_on_attachments do
+      true
     end
   end
 end

--- a/lib/decidim/reporting_proposals/engine.rb
+++ b/lib/decidim/reporting_proposals/engine.rb
@@ -25,6 +25,7 @@ module Decidim
           Decidim::CreateReport.include(Decidim::ReportingProposals::CreateReportOverride)
           ComponentValidator.include(Decidim::ReportingProposals::ComponentValidatorOverride)
           Decidim::Map::Autocomplete::Builder.include(Decidim::ReportingProposals::MapBuilderOverride)
+          Decidim::FormBuilder.include(Decidim::ReportingProposals::FormBuilderOverride)
         end
       end
 

--- a/spec/forms/proposal_form_spec.rb
+++ b/spec/forms/proposal_form_spec.rb
@@ -23,7 +23,9 @@ module Decidim
       let(:latitude) { 40.1234 }
       let(:longitude) { 2.1234 }
       let(:has_no_address) { false }
+      let(:has_no_image) { false }
       let(:address) { "Some address" }
+      let(:image) { Decidim::Dev.asset("city.jpeg") }
       let(:suggested_hashtags) { [] }
       let(:attachment_params) { nil }
       let(:meeting_as_author) { false }
@@ -38,6 +40,8 @@ module Decidim
           latitude: latitude,
           longitude: longitude,
           has_no_address: has_no_address,
+          has_no_image: has_no_image,
+          add_photos: image,
           meeting_as_author: meeting_as_author,
           attachment: attachment_params,
           suggested_hashtags: suggested_hashtags
@@ -76,6 +80,18 @@ module Decidim
 
         context "and address is not required" do
           let(:has_no_address) { true }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context "when there's no image" do
+        let(:image) { nil }
+
+        it { is_expected.to be_invalid }
+
+        context "and image is not required" do
+          let(:has_no_image) { true }
 
           it { is_expected.to be_valid }
         end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -11,6 +11,7 @@ checksums = [
     files: {
       "/lib/decidim/component_validator.rb" => "2e3eb588a9579b94c21f4f440751d9a9",
       "/lib/decidim/map/autocomplete.rb" => "65df8e58433814e6b35b52c1bff19ed2",
+      "/lib/decidim/form_builder.rb" => "91c55f8197a9e3892e94f5c13ca40905",
       "/app/commands/decidim/create_report.rb" => "41c95f194f5ccb5ff32efc43644c9ce5"
     }
   },

--- a/spec/system/device_camera_spec.rb
+++ b/spec/system/device_camera_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "User camera button", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "reporting_proposals" }
+  let!(:component) do
+    create(:reporting_proposals_component,
+           :with_extra_hashtags,
+           participatory_space: participatory_process,
+           settings: { only_photo_attachments: false })
+  end
+  let!(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:proposal) { Decidim::Proposals::Proposal.last }
+  let(:all_manifests) { [:proposals, :reporting_proposals] }
+  let(:manifests) { all_manifests }
+  let(:camera_on_attachments) { true }
+
+  before do
+    allow(Decidim::ReportingProposals).to receive(:use_camera_button).and_return(manifests)
+    allow(Decidim::ReportingProposals).to receive(:camera_button_on_attachments).and_return(camera_on_attachments)
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  shared_examples "uses device camera" do
+    it "has two cameras button" do
+      expect(page).to have_button("Use my camera", count: 2)
+    end
+
+    context "when no camera on attachments" do
+      let(:camera_on_attachments) { false }
+
+      it "has one camera button" do
+        expect(page).to have_button("Use my camera", count: 1)
+      end
+    end
+
+    context "when option disabled" do
+      let(:manifests) { all_manifests - [component.manifest_name.to_sym] }
+
+      it "does not has the camera button" do
+        expect(page).not_to have_button("Use my camera")
+      end
+    end
+  end
+
+  shared_examples "uses admin device camera" do
+    it "has one camera button" do
+      expect(page).to have_button("Use my camera", count: 1)
+    end
+
+    context "when option disabled" do
+      let(:manifests) { all_manifests - [component.manifest_name.to_sym] }
+
+      it "does not has the camera button" do
+        expect(page).not_to have_button("Use my camera")
+      end
+    end
+  end
+
+  describe "#reporting_proposals" do
+    before do
+      visit_component
+      click_link "New proposal"
+    end
+
+    it_behaves_like "uses device camera"
+  end
+
+  context "when admin" do
+    before do
+      visit manage_component_path(component)
+      click_link "New proposal"
+    end
+
+    it_behaves_like "uses admin device camera"
+  end
+
+  describe "#proposals" do
+    let(:manifest_name) { "proposals" }
+    let!(:component) do
+      create(:proposal_component,
+             :with_creation_enabled,
+             :with_attachments_allowed,
+             participatory_space: participatory_process)
+    end
+    let(:proposal) { create(:proposal, :draft, component: component, users: [user]) }
+
+    before do
+      visit_component
+      visit "#{Decidim::EngineRouter.main_proxy(component).proposal_path(proposal)}/complete"
+    end
+
+    it_behaves_like "uses device camera"
+
+    context "when admin" do
+      before do
+        visit manage_component_path(component)
+        click_link "New proposal"
+      end
+
+      it_behaves_like "uses admin device camera"
+    end
+  end
+end

--- a/spec/system/device_location_spec.rb
+++ b/spec/system/device_location_spec.rb
@@ -5,28 +5,16 @@ require "spec_helper"
 describe "User location button", type: :system do
   include_context "with a component"
   let(:manifest_name) { "reporting_proposals" }
-  let!(:scope) { create :scope, organization: organization }
   let!(:component) do
     create(:reporting_proposals_component,
            :with_extra_hashtags,
-           participatory_space: participatory_process,
-           suggested_hashtags: suggested_hashtags,
-           automatic_hashtags: automatic_hashtags,
-           settings: { scopes_enabled: true })
+           participatory_space: participatory_process)
   end
-  let(:automatic_hashtags) { "HashtagAuto1 HashtagAuto2" }
-  let(:suggested_hashtags) { "HashtagSuggested1 HashtagSuggested2" }
   let!(:user) { create(:user, :admin, :confirmed, organization: organization) }
-  let!(:user_group) { create(:user_group, :verified, users: [user], organization: organization) }
-  let(:proposal_title) { "More sidewalks and less roads" }
-  let(:proposal_body) { "Cities need more people, not more cars" }
-  let(:proposal_category) { category }
   let(:proposal) { Decidim::Proposals::Proposal.last }
-  let!(:another_category) { create :category, participatory_space: participatory_process }
   let(:address) { "Plaça Santa Jaume, 1, 08002 Barcelona" }
   let(:latitude) { 41.3825 }
   let(:longitude) { 2.1772 }
-  let(:scope_picker) { select_data_picker(:proposal_scope_id) }
   let(:all_manifests) { [:proposals, :meetings, :reporting_proposals] }
   let(:manifests) { all_manifests }
 

--- a/spec/system/reporting_proposals_spec.rb
+++ b/spec/system/reporting_proposals_spec.rb
@@ -55,7 +55,7 @@ describe "Reporting proposals overrides", type: :system do
         attach_file(:proposal_add_photos, Decidim::Dev.asset("city.jpeg"))
         attach_file(:proposal_add_documents, Decidim::Dev.asset("Exampledocument.pdf"))
       else
-        check "proposal_has_no_image"
+        check "proposal_has_no_image" if manifest_name == "reporting_proposals"
       end
 
       find("*[type=submit]").click

--- a/spec/system/reporting_proposals_spec.rb
+++ b/spec/system/reporting_proposals_spec.rb
@@ -7,13 +7,15 @@ describe "Reporting proposals overrides", type: :system do
   include_context "with a component"
   let(:manifest_name) { "reporting_proposals" }
   let!(:scope) { create :scope, organization: organization }
+  let(:only_photos) { false }
+  let(:attachments) { true }
   let!(:component) do
     create(:reporting_proposals_component,
            :with_extra_hashtags,
            participatory_space: participatory_process,
            suggested_hashtags: suggested_hashtags,
            automatic_hashtags: automatic_hashtags,
-           settings: { scopes_enabled: true })
+           settings: { scopes_enabled: true, attachments_allowed: attachments, only_photo_attachments: only_photos })
   end
   let(:automatic_hashtags) { "HashtagAuto1 HashtagAuto2" }
   let(:suggested_hashtags) { "HashtagSuggested1 HashtagSuggested2" }
@@ -49,8 +51,12 @@ describe "Reporting proposals overrides", type: :system do
       end
 
       check "proposal_has_no_address" if skip_address
-      attach_file(:proposal_add_photos, Decidim::Dev.asset("city.jpeg")) if attach
-      attach_file(:proposal_add_documents, Decidim::Dev.asset("Exampledocument.pdf")) if attach
+      if attach
+        attach_file(:proposal_add_photos, Decidim::Dev.asset("city.jpeg"))
+        attach_file(:proposal_add_documents, Decidim::Dev.asset("Exampledocument.pdf"))
+      else
+        check "proposal_has_no_image"
+      end
 
       find("*[type=submit]").click
     end
@@ -61,8 +67,10 @@ describe "Reporting proposals overrides", type: :system do
       select translated(another_category.name), from: :proposal_category_id
       select user_group.name, from: :proposal_user_group_id
 
-      attach_file(:proposal_add_photos, Decidim::Dev.asset("city.jpeg")) if attach
-      attach_file(:proposal_add_documents, Decidim::Dev.asset("Exampledocument.pdf")) if attach
+      if attach
+        attach_file(:proposal_add_photos, Decidim::Dev.asset("city.jpeg"))
+        attach_file(:proposal_add_documents, Decidim::Dev.asset("Exampledocument.pdf"))
+      end
 
       find("*[type=submit]").click
     end
@@ -71,6 +79,7 @@ describe "Reporting proposals overrides", type: :system do
   context "when creating a new proposal", :serves_geocoding_autocomplete do
     before do
       visit_component
+      click_link "New proposal"
     end
 
     it_behaves_like "3 steps"
@@ -88,6 +97,7 @@ describe "Reporting proposals overrides", type: :system do
 
     before do
       visit_component
+      click_link "New proposal"
     end
 
     it_behaves_like "4 steps"

--- a/spec/system/reporting_proposals_spec.rb
+++ b/spec/system/reporting_proposals_spec.rb
@@ -54,8 +54,8 @@ describe "Reporting proposals overrides", type: :system do
       if attach
         attach_file(:proposal_add_photos, Decidim::Dev.asset("city.jpeg"))
         attach_file(:proposal_add_documents, Decidim::Dev.asset("Exampledocument.pdf"))
-      else
-        check "proposal_has_no_image" if manifest_name == "reporting_proposals"
+      elsif manifest_name == "reporting_proposals"
+        check "proposal_has_no_image"
       end
 
       find("*[type=submit]").click

--- a/spec/system/shared/proposals_steps_examples.rb
+++ b/spec/system/shared/proposals_steps_examples.rb
@@ -2,8 +2,6 @@
 
 shared_examples "map can be hidden" do
   it "checkbox hides the map" do
-    click_link "New proposal"
-
     fill_in :proposal_address, with: address
     within ".tribute-container" do
       page.find("li", match: :first).click
@@ -18,8 +16,6 @@ end
 
 shared_examples "map can be shown" do
   it "checkbox shows the map" do
-    click_link "New proposal"
-
     fill_proposal(extra_fields: false)
 
     expect(page).not_to have_content("You can move the point on the map")
@@ -35,8 +31,6 @@ end
 
 shared_examples "3 steps" do
   it "sidebar does not have the complete step" do
-    click_link "New proposal"
-
     expect(page).to have_content("Step 1 of 3")
     within ".wizard__steps" do
       expect(page).not_to have_content("Complete")
@@ -44,8 +38,6 @@ shared_examples "3 steps" do
   end
 
   it "redirects to the publish step" do
-    click_link "New proposal"
-
     fill_proposal
 
     expect(page).to have_content(proposal_title)
@@ -62,17 +54,34 @@ shared_examples "3 steps" do
     let!(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: proposal_title, body: proposal_body) }
 
     it "redirects to complete" do
+      visit_component
       click_link "New proposal"
 
       expect(page).to have_content("EDIT PROPOSAL DRAFT")
     end
   end
 
+  context "when only_photo_attachments is enabled" do
+    let(:only_photos) { true }
+
+    it "does not show the attachments" do
+      expect(page).not_to have_content("Add an attachment")
+      expect(page).to have_content("Image/photo")
+    end
+
+    context "and attachment are not active" do
+      let(:attachments) { false }
+
+      it "does not show the attachments or photos" do
+        expect(page).not_to have_content("Add an attachment")
+        expect(page).not_to have_content("Image/photo")
+      end
+    end
+  end
+
   it_behaves_like "map can be hidden"
 
   it "publishes the reporting proposal" do
-    click_link "New proposal"
-
     fill_proposal
 
     click_button "Publish"
@@ -95,8 +104,6 @@ shared_examples "3 steps" do
   end
 
   it "uploads attachments", :slow do
-    click_link "New proposal"
-
     fill_proposal(attach: true, extra_fields: false, skip_address: true)
 
     expect(page).to have_content(proposal_title)
@@ -105,8 +112,6 @@ shared_examples "3 steps" do
   end
 
   it "modifies the proposal" do
-    click_link "New proposal"
-
     fill_proposal
 
     expect(page).not_to have_content("RELATED IMAGES")
@@ -129,8 +134,6 @@ shared_examples "3 steps" do
   end
 
   it "stores no address if checked" do
-    click_link "New proposal"
-
     fill_proposal(skip_address: true, skip_group: true, skip_scope: true)
 
     click_button "Publish"
@@ -150,8 +153,6 @@ end
 
 shared_examples "4 steps" do
   it "sidebar has the complete step" do
-    click_link "New proposal"
-
     expect(page).to have_content("Step 1 of 4")
     within ".wizard__steps" do
       expect(page).to have_content("Complete")
@@ -161,8 +162,6 @@ shared_examples "4 steps" do
   it_behaves_like "map can be shown"
 
   it "redirects to the complete step" do
-    click_link "New proposal"
-
     fill_proposal(extra_fields: false)
 
     within ".section-heading" do
@@ -173,8 +172,6 @@ shared_examples "4 steps" do
   end
 
   it "publishes the proposal" do
-    click_link "New proposal"
-
     fill_proposal(extra_fields: false)
     expect(proposal.identities.first).to eq(user)
 


### PR DESCRIPTION
Adds a button in upload file for proposals or meetings to quickly use the camera if using a mobile

- [x] Add entrypoints/scripts/css
- [x] Add button, open camera (if available)
- [ ] Do not show the button on desktop
- [x] Add a configuration option for this
- [ ] Specs

Screenshots:

![image](https://user-images.githubusercontent.com/1401520/193081129-91734499-165d-46e4-9c84-fd612d7da385.png)
