### PR TITLE
Don't rely on multi-language tabs-panel being present

### DIFF
--- a/app/packs/src/decidim/templates/admin/proposal_answer_template_chooser.js
+++ b/app/packs/src/decidim/templates/admin/proposal_answer_template_chooser.js
@@ -12,7 +12,7 @@ $(() => {
     }).done((data) => {
       $(`#proposal_answer_internal_state_${data.state}`).trigger("click");
 
-      const $editors = $dropDown.parent().parent().find(".tabs-panel").find(".editor-container");
+      const $editors = $dropDown.parent().parent().find(".editor-container");
       $editors.each((index, element) => {
         const localElement = $(element);
         const $locale = localElement.siblings("input[type=hidden]").attr("id").replace("proposal_answer_answer_", "");


### PR DESCRIPTION
On decidim organizations which have only one language activated, the editors are not wrapped into .tabs-panel elements. On these platforms, the proposal answer template body was not being filled in, because the editor was not found.

Fixes https://github.com/stadtluzern/decidim-ocl/issues/269