### PR TITLE
Add missing translations in permissions

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -179,13 +179,20 @@ ca:
         admin_resource: Administra el recurs
     reporting_proposals:
       actions:
+        amend: Esmena
         answer_proposal: Resposta de la proposta
+        comment: Comentar
+        create: Crear
         edit_proposal: Edita la proposta
+        endorse: Adherir-se
         import: Importa propostes d'un altre component
         new: Nova proposta
         participatory_texts: Textos participatius
         show: Veure proposta
         title: Accions
+        vote: Donar suport
+        vote_comment: Votar el comentari
+        withdraw: Retirar
       admin:
         actions:
           edit_valuators: Edita les avaluadores

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -181,13 +181,20 @@ de:
         admin_resource: Diese Ressource moderieren
     reporting_proposals:
       actions:
+        amend: Änderungsvorschlag
         answer_proposal: Meldung beantworten
+        comment: Kommentieren
+        create: Erstellen
         edit_proposal: Meldung bearbeiten
+        endorse: Unterstützung
         import: Meldungen aus einer anderen Komponente importieren
         new: Neue Meldung
         participatory_texts: Partizipative Texte
         show: Meldung anzeigen
         title: Aktionen
+        vote: Abstimmung
+        vote_comment: Kommentar bewerten
+        withdraw: Zurückziehen
       admin:
         actions:
           edit_valuators: Experten ändern

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,13 +235,20 @@ en:
         admin_resource: Admin this resource
     reporting_proposals:
       actions:
+        amend: Amend
         answer_proposal: Answer proposal
+        comment: Comment
+        create: Create
         edit_proposal: Edit proposal
+        endorse: Endorse
         import: Import proposals from another component
         new: New proposal
         participatory_texts: Participatory texts
         show: Show proposal
         title: Actions
+        vote: Support
+        vote_comment: Vote comment
+        withdraw: Withdraw
       admin:
         actions:
           edit_valuators: Edit valuators

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -181,13 +181,20 @@ es:
         admin_resource: Administrar este recurso
     reporting_proposals:
       actions:
+        amend: Enmendar
         answer_proposal: Responder a la propuesta
+        comment: Comentar
+        create: Crear
         edit_proposal: Editar propuesta
+        endorse: Adherirse
         import: Importar propuestas de otro componente
         new: Nueva propuesta
         participatory_texts: Textos participativos
         show: Ver propuesta
         title: Acciones
+        vote: Dar apoyo
+        vote_comment: Votar comentario
+        withdraw: Retirar
       admin:
         actions:
           edit_valuators: Editar evaluadores


### PR DESCRIPTION
Permissions view through missing translation error:

![image](https://github.com/user-attachments/assets/cda1b6e0-1251-496e-8fbf-117b850b82f2)

This PR add missing translations

![Screenshot from 2024-10-15 10-57-15](https://github.com/user-attachments/assets/1749c1d4-40bf-4f9a-afad-afaf9b3db2a9)

