### PR TITLE
Fix form builder when is used in system

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -121,7 +121,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: workspace
           path: /tmp

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -120,6 +120,9 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
+      
+      - name: Install imagemagick
+        run: sudo apt install -y imagemagick
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -65,7 +65,7 @@ jobs:
 
       - run: tar -zcf /tmp/testapp-env.tar.gz ./spec/decidim_dummy_app
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: workspace
           path: /tmp/testapp-env.tar.gz
@@ -140,7 +140,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots-${{ matrix.name }}

--- a/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
+++ b/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
@@ -10,9 +10,12 @@ module Decidim
       delegate :asset_pack_path, to: :@template
 
       included do
+
+        alias_method :original_file_field, :file_field
+  
         def file_field(object_name, options = {})
           return super(object_name, options) unless Decidim::ReportingProposals.use_camera_button
-          return super(object_name, options) if @object_name == "editor_image" || @object_name == "oauth_application"
+          return original_file_field unless @template.respond_to?(:snippets)
 
           unless @template.snippets.any?(:reporting_proposals_camera_scripts) || @template.snippets.any?(:reporting_proposals_camera_styles)
             @template.snippets.add(:reporting_proposals_camera_scripts, @template.prepend_javascript_pack_tag("decidim_reporting_proposals_camera"))

--- a/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
+++ b/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
@@ -13,8 +13,8 @@ module Decidim
         alias_method :original_file_field, :file_field
 
         def file_field(object_name, options = {})
-          return super(object_name, options) unless Decidim::ReportingProposals.use_camera_button
-          return original_file_field unless @template.respond_to?(:snippets)
+        return original_file_field(object_name, options) unless Decidim::ReportingProposals.use_camera_button
+        return original_file_field(object_name, options) unless @template.respond_to?(:snippets)
 
           unless @template.snippets.any?(:reporting_proposals_camera_scripts) || @template.snippets.any?(:reporting_proposals_camera_styles)
             @template.snippets.add(:reporting_proposals_camera_scripts, @template.prepend_javascript_pack_tag("decidim_reporting_proposals_camera"))

--- a/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
+++ b/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
@@ -10,9 +10,8 @@ module Decidim
       delegate :asset_pack_path, to: :@template
 
       included do
-
         alias_method :original_file_field, :file_field
-  
+
         def file_field(object_name, options = {})
           return super(object_name, options) unless Decidim::ReportingProposals.use_camera_button
           return original_file_field unless @template.respond_to?(:snippets)

--- a/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
+++ b/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
@@ -12,6 +12,7 @@ module Decidim
       included do
         def file_field(object_name, options = {})
           return super(object_name, options) unless Decidim::ReportingProposals.use_camera_button
+          return super(object_name, options) if @object_name == "editor_image" || @object_name == "oauth_application"
 
           unless @template.snippets.any?(:reporting_proposals_camera_scripts) || @template.snippets.any?(:reporting_proposals_camera_styles)
             @template.snippets.add(:reporting_proposals_camera_scripts, @template.prepend_javascript_pack_tag("decidim_reporting_proposals_camera"))

--- a/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
+++ b/app/forms/concerns/decidim/reporting_proposals/form_builder_override.rb
@@ -13,8 +13,8 @@ module Decidim
         alias_method :original_file_field, :file_field
 
         def file_field(object_name, options = {})
-        return original_file_field(object_name, options) unless Decidim::ReportingProposals.use_camera_button
-        return original_file_field(object_name, options) unless @template.respond_to?(:snippets)
+          return original_file_field(object_name, options) unless Decidim::ReportingProposals.use_camera_button
+          return original_file_field(object_name, options) unless @template.respond_to?(:snippets)
 
           unless @template.snippets.any?(:reporting_proposals_camera_scripts) || @template.snippets.any?(:reporting_proposals_camera_styles)
             @template.snippets.add(:reporting_proposals_camera_scripts, @template.prepend_javascript_pack_tag("decidim_reporting_proposals_camera"))


### PR DESCRIPTION
There is an error when the form builder is used in /system when you edit an organization.

![imagen](https://github.com/user-attachments/assets/daf48267-d86d-4dbf-986c-8008f73582c0)

